### PR TITLE
Shared preference key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,18 @@ This is the part where the manual comment comes in when adding a new migration h
 2. Add the name file name EXACTLY as it is into the list of `migrationFiles` for the `runMigration` function.
 
 And that's basically it. Migration files in sql format, separated by semi-colons and automatically applied based on the version of your current database which persists properly over deployments. If you have any issues, don't hesitate to file it. 
+
+### Custom database version key in shared preferences
+
+The database version number is stored in shared preferences with the key `database_version_key` by default. That key can be changed by passing the parameter `databaseVersionKey` when calling `runMigration` of `DatabaseService`.
+
+```dart
+  await _migrationService.runMigration(
+    _database,
+    migrationFiles: [
+      '1_create_schema.sql',
+      '2_add_description.sql',
+    ],
+    databaseVersionKey: 'custom_db_version_key'
+  );
+```

--- a/lib/src/database_migration_service.dart
+++ b/lib/src/database_migration_service.dart
@@ -66,11 +66,20 @@ class DatabaseMigrationService {
     Database database, {
     @required List<String> migrationFiles,
     bool verbose = false,
+    String databaseVersionKey
   }) async {
     // Only perform the setup once when calling runMigration
     if (!_setupComplete) {
       await _setupLocator();
       _setupComplete = true;
+    }
+
+    if (databaseVersionKey != null) {
+      _sharedPreferences.databaseVersionKey = databaseVersionKey;
+    }
+
+    if (verbose) {
+      print('DatabaseMigrationService - Shared Preferences Key: ${_sharedPreferences.databaseVersionKey}');
     }
 
     // #1: Get the current database version from Shared Preferences

--- a/lib/src/shared_preferences_service.dart
+++ b/lib/src/shared_preferences_service.dart
@@ -20,11 +20,16 @@ class SharedPreferencesService {
     this.enableLogs,
   );
 
-  static const _DatabaseVersionKey = 'database_version_key';
+  static const _DefaultDatabaseVersionKey = 'database_version_key';
+  String _databaseVersionKey;
 
-  int get databaseVersion => _getFromDisk(_DatabaseVersionKey) ?? 0;
+  String get databaseVersionKey => _databaseVersionKey ?? _DefaultDatabaseVersionKey;
 
-  set databaseVersion(int value) => _saveToDisk(_DatabaseVersionKey, value);
+  set databaseVersionKey(String key) => _databaseVersionKey = key;
+
+  int get databaseVersion => _getFromDisk(databaseVersionKey) ?? 0;
+
+  set databaseVersion(int value) => _saveToDisk(databaseVersionKey, value);
 
   void clearPreferences() {
     _preferences.clear();

--- a/test/database_migration_service_test.dart
+++ b/test/database_migration_service_test.dart
@@ -99,6 +99,15 @@ void main() {
             .runMigration(database, migrationFiles: ['1_migration.sql']);
         verify(sharedPreferences.databaseVersion = 1);
       });
+
+      test('When given databaseVersionKey parameter, it should be set in SharedPreferencesService', () async {
+        var database = getDatabaseMock();
+        var sharedPreferences = getAndRegisterSharedPreferencesMock();
+        var migrationHelper = DatabaseMigrationService();
+        final String databaseVersionKey = 'custom_db_version_key';
+        await migrationHelper.runMigration(database, migrationFiles: [], databaseVersionKey: databaseVersionKey);
+        verify(sharedPreferences.databaseVersionKey = databaseVersionKey);
+      });
     });
 
     group('getMigrationQueriesFromScript -', () {

--- a/test/database_migration_service_test.dart
+++ b/test/database_migration_service_test.dart
@@ -101,13 +101,23 @@ void main() {
       });
 
       test('When given databaseVersionKey parameter, it should be set in SharedPreferencesService', () async {
-        var database = getDatabaseMock();
-        var sharedPreferences = getAndRegisterSharedPreferencesMock();
-        var migrationHelper = DatabaseMigrationService();
         final String databaseVersionKey = 'custom_db_version_key';
+        var database = getDatabaseMock();
+        var sharedPreferences = getAndRegisterSharedPreferencesMock(databaseVersionKey: databaseVersionKey);
+        var migrationHelper = DatabaseMigrationService();
         await migrationHelper.runMigration(database, migrationFiles: [], databaseVersionKey: databaseVersionKey);
         verify(sharedPreferences.databaseVersionKey = databaseVersionKey);
+        expect(sharedPreferences.databaseVersionKey, databaseVersionKey);
       });
+    });
+
+    test('When not given databaseVersionKey parameter, it should not be set in SharedPreferences and default value should be returned', () async {
+      var database = getDatabaseMock();
+      var sharedPreferences = getAndRegisterSharedPreferencesMock();
+      var migrationHelper = DatabaseMigrationService();
+      await migrationHelper.runMigration(database, migrationFiles: []);
+      verifyNever(sharedPreferences.databaseVersionKey = null);
+      expect(sharedPreferences.databaseVersionKey, defaultDatabaseVersionKey);
     });
 
     group('getMigrationQueriesFromScript -', () {

--- a/test/setup/test_helpers.dart
+++ b/test/setup/test_helpers.dart
@@ -10,12 +10,15 @@ class AssetReaderMock extends Mock implements AssetReader {}
 
 class DatabaseMock extends Mock implements Database {}
 
+const String defaultDatabaseVersionKey = 'database_version_key';
+
 SharedPreferencesService getAndRegisterSharedPreferencesMock(
-    {int databaseVersion = 0}) {
+    {int databaseVersion = 0, String databaseVersionKey = defaultDatabaseVersionKey}) {
   _removeRegistrationIfExists<SharedPreferencesService>();
   var preferencesMock = SharedPreferencesMock();
 
   when(preferencesMock.databaseVersion).thenReturn(databaseVersion);
+  when(preferencesMock.databaseVersionKey).thenReturn(databaseVersionKey);
 
   locator.registerSingleton<SharedPreferencesService>(preferencesMock);
   return preferencesMock;


### PR DESCRIPTION
The goal of this PR is to allow users to customize the database version key.

**Problem**
In case that your app uses more than one database, the library cannot manage multiple databases versions. The limitation is because the key is a hardcoded string in **SharedPreferencesService**.

**Solution**
I added the parameter **databaseVersionKey** in the **runMigration** method of **DatabaseMigrationService**, so users can customize the database version key used in shared preferences. To pass this value to **SharedPreferencesService**, I added the property **databaseVersionKey** with a setter and getter. By default is null. If **databaseVersionKey** is null, the getter will return a default value.

**Example**
```
String _userId;

Future<Database> get database async {
    if (_database == null) {
      _database = await _initialize();
    }
    return _database;
  }

_initialize() async {
    String dbName = "${_userId}_database.db";
    Directory docDir = await getApplicationDocumentsDirectory();
    String path = join(docDir.path, dbName);

    Database db = await openDatabase(
      path,
      version: 1,
      onOpen: (db) {
        print('Database Open');
      },
    );
    await _executeMigrations(db);

    return db;
  }

  void _executeMigrations(Database db) async {
    final String sharedPreferenceKey = 'database_version_key.${_userId}';

    await _migrationService.runMigration(
        db,
        migrationFiles: migrations,
        verbose: true,
        databaseVersionKey: sharedPreferenceKey
    );
  }
```